### PR TITLE
Errores por desbloquear niveles

### DIFF
--- a/src/pages/select-difficulty/select-difficulty.ts
+++ b/src/pages/select-difficulty/select-difficulty.ts
@@ -124,7 +124,7 @@ export class SelectDifficultyPage {
             
             this.navCtrl.push(SupermarketPage, {level:LoginStatus.userProgress.easyLevelSuper,maxLevel:LoginStatus.userProgress.easyLevelSuper });
         }else{
-            this.navCtrl.push(WordPage, {level:LoginStatus.userProgress.easyLevel });
+            this.navCtrl.push(WordPage, {level:LoginStatus.userProgress.easyLevel,maxLevel:200 });
         }
           
     }
@@ -134,7 +134,7 @@ export class SelectDifficultyPage {
         if(this.typeOfGame==="supermarket"){
             this.navCtrl.push(SupermarketPage, {level:LoginStatus.userProgress.mediumLevelSuper,maxLevel:LoginStatus.userProgress.mediumLevelSuper });
         }else{
-            this.navCtrl.push(WordPage, {level:LoginStatus.userProgress.mediumLevel });
+            this.navCtrl.push(WordPage, {level:LoginStatus.userProgress.mediumLevel,maxLevel:200 });
         }
     }
 
@@ -142,7 +142,7 @@ export class SelectDifficultyPage {
         if(this.typeOfGame==="supermarket"){ 
             this.navCtrl.push(SupermarketPage, {level:LoginStatus.userProgress.hardLevelSuper,maxLevel:LoginStatus.userProgress.hardLevelSuper });
         }else{
-            this.navCtrl.push(WordPage, {level:LoginStatus.userProgress.hardLevel });
+            this.navCtrl.push(WordPage, {level:LoginStatus.userProgress.hardLevel,maxLevel:200 });
         }
     }
 
@@ -150,7 +150,7 @@ export class SelectDifficultyPage {
         if(this.typeOfGame==="supermarket"){
             this.navCtrl.push(SupermarketPage, {level:LoginStatus.userProgress.extremeLevelSuper,maxLevel:LoginStatus.userProgress.extremeLevelSuper});
         }else{
-            this.navCtrl.push(WordPage, {level:LoginStatus.userProgress.extremeLevel });
+            this.navCtrl.push(WordPage, {level:LoginStatus.userProgress.extremeLevel,maxLevel:200 });
      }
     }
 

--- a/src/pages/select-level/select-level.ts
+++ b/src/pages/select-level/select-level.ts
@@ -73,9 +73,15 @@ export class SelectLevelPage {
   }
   setupUnlockedLevels()
   {
-    this.levelEnabled=this.thisLevelIsUnlocked();
-    this.levelAvaiableToUnlock=this.isAvaiableToUnlocked();
-    this.hasMoney=LoginStatus.userProgress.coins>=25;
+    if(this.typeOfGame==="words"){
+      this.levelEnabled=this.thisLevelIsUnlocked();
+      this.levelAvaiableToUnlock=this.isAvaiableToUnlocked();
+      this.hasMoney=LoginStatus.userProgress.coins>=25;
+    }else{
+      this.levelEnabled=true;
+      this.levelAvaiableToUnlock=false;
+      this.hasMoney=true;
+    }
   }
   previus()
   {

--- a/src/pages/select-level/select-level.ts
+++ b/src/pages/select-level/select-level.ts
@@ -46,7 +46,8 @@ export class SelectLevelPage {
     }else{
       this.minLevel=1;
     }
-    this.maxLevel=200;
+    this.maxLevel=this.navParams.get("maxLevel");
+    console.log("min level: "+this.minLevel+" maxLevel: "+this.maxLevel);
   }
   public async buyLevel(){
     await this.login.buyLevel();

--- a/src/pages/word/word.ts
+++ b/src/pages/word/word.ts
@@ -112,7 +112,7 @@ export class WordPage implements OnInit, AfterViewInit, OnDestroy {
     }
 
     public showModalWin(): void {
-        const levelCompleteModal = this.modalController.create(LevelCompletePage, {level: this.game.Level + 1, lastNav:this.navController});
+        const levelCompleteModal = this.modalController.create(LevelCompletePage, {level: this.game.Level + 1, lastNav:this.navController,maxLevel:200});
         levelCompleteModal.present();
     }
 


### PR DESCRIPTION
El nivel máximo puesto en 200 en el juego de palabras afectaba en cantidad de niveles posibles a jugar en el juego de supermercado, junto con las condiciones para desbloquear que habían en el juego de palabras.